### PR TITLE
Steering logic patch

### DIFF
--- a/src/main/java/edn/stratodonut/trackwork/tracks/blocks/WheelBlockEntity.java
+++ b/src/main/java/edn/stratodonut/trackwork/tracks/blocks/WheelBlockEntity.java
@@ -213,7 +213,16 @@ public class WheelBlockEntity extends KineticBlockEntity {
                 this.steeringValue = Mth.lerp(steeringSpeed, this.steeringValue, targetSteeringValue);
 
                 float deltaSteeringValue = oldSteeringValue - this.steeringValue;
-                this.onLinkedWheel(wbe -> wbe.setLinkedSteeringValue(this.steeringValue));
+
+                // Flush linked val & propagate when pair target empty
+                if (bestSignal > 0) this.linkedSteeringValue = 0f;
+                this.onLinkedWheel(wbe -> {
+                    int linkedSignal = this.level.getBestNeighborSignal(wbe.getBlockPos());
+                    if (linkedSignal == 0) {
+                        wbe.setLinkedSteeringValue(this.steeringValue);
+                    }
+                });
+
                 SimpleWheelController controller = SimpleWheelController.getOrCreate(ship);
                 SimpleWheelData.SimpleWheelUpdateData data = new SimpleWheelData.SimpleWheelUpdateData(
                         this.getSteeringValue(),


### PR DESCRIPTION
## Fix a previously unknown bug in steering logic that is revealed when Potato decide to add steering interpolation.

### Old
- Wheel A steer, propagate to wheel B regardless. -> when both wheel gets a signal or when B gets a signal *after* A, the wheel "lags" and then snap into correct position as B tries and fail to interpolate the new signal, interpolating to A's position before trying to get to it's own position. This causes it to "snap" to the final pos without lerping while also taking the same amt of time it would otherwise.

### Fix
- Flush the wheel link value when wheel B has it's own signal -> goes from 0 -> B instead of A -> B (fix for lerping when B has signal later than A),
- Makes the A propagating logic check for B's current value -> skip propagation if B has it's own business (main fix for when both wheel gets powered).