### PR TITLE
Fix belted shafts not connecting to wheels

### DIFF
--- a/src/main/java/edn/stratodonut/trackwork/items/TrackToolkit.java
+++ b/src/main/java/edn/stratodonut/trackwork/items/TrackToolkit.java
@@ -101,6 +101,8 @@ public class TrackToolkit extends Item {
                         if (ship == null) return InteractionResult.FAIL;
                         owbe.setOffset(VectorConversionsMCKt.toJOML(context.getClickLocation().subtract(Vec3.atCenterOf(context.getClickedPos()))),
                                 context.getClickedFace());
+
+                        return InteractionResult.SUCCESS;
                     }
                 }
                 case STIFFNESS -> {

--- a/src/main/java/edn/stratodonut/trackwork/tracks/blocks/WheelBlockEntity.java
+++ b/src/main/java/edn/stratodonut/trackwork/tracks/blocks/WheelBlockEntity.java
@@ -187,7 +187,7 @@ public class WheelBlockEntity extends KineticBlockEntity {
         Direction dir = this.getBlockState().getValue(HORIZONTAL_FACING);
         BlockPos innerBlock = this.getBlockPos().relative(dir);
         BlockState innerState = this.level.getBlockState(innerBlock);
-        if (innerState.getBlock() instanceof KineticBlock ke && ke.hasShaftTowards(level, this.getBlockPos(), innerState, dir.getOpposite())) {
+        if (innerState.getBlock() instanceof KineticBlock ke && ke.hasShaftTowards(level, innerBlock, innerState, dir.getOpposite())) {
             isFreespin = false;
         } else {
             isFreespin = true;

--- a/src/main/java/edn/stratodonut/trackwork/tracks/blocks/WheelBlockEntity.java
+++ b/src/main/java/edn/stratodonut/trackwork/tracks/blocks/WheelBlockEntity.java
@@ -185,7 +185,17 @@ public class WheelBlockEntity extends KineticBlockEntity {
         Direction dir = this.getBlockState().getValue(HORIZONTAL_FACING);
         BlockPos innerBlock = this.getBlockPos().relative(dir);
         BlockState innerState = this.level.getBlockState(innerBlock);
-        if (innerState.getBlock() instanceof KineticBlock ke && ke.hasShaftTowards(level, this.getBlockPos(), innerState, dir.getOpposite())) {
+        boolean hasKineticConnection = false;
+        Direction.Axis wheelAxis = dir.getAxis();
+
+        if (innerState.getBlock() instanceof KineticBlock ke) {
+            boolean hasShaft = ke.hasShaftTowards(level, this.getBlockPos(), innerState, dir.getOpposite());
+            //Axis check for Belted shaft (they don't count as "shaft" shaft)
+            boolean compatibleAxis = ke.getRotationAxis(innerState) == wheelAxis;
+            hasKineticConnection = hasShaft || compatibleAxis;
+        }
+
+        if (hasKineticConnection) {
             isFreespin = false;
         } else {
             isFreespin = true;

--- a/src/main/java/edn/stratodonut/trackwork/tracks/blocks/WheelBlockEntity.java
+++ b/src/main/java/edn/stratodonut/trackwork/tracks/blocks/WheelBlockEntity.java
@@ -187,17 +187,7 @@ public class WheelBlockEntity extends KineticBlockEntity {
         Direction dir = this.getBlockState().getValue(HORIZONTAL_FACING);
         BlockPos innerBlock = this.getBlockPos().relative(dir);
         BlockState innerState = this.level.getBlockState(innerBlock);
-        boolean hasKineticConnection = false;
-        Direction.Axis wheelAxis = dir.getAxis();
-
-        if (innerState.getBlock() instanceof KineticBlock ke) {
-            boolean hasShaft = ke.hasShaftTowards(level, this.getBlockPos(), innerState, dir.getOpposite());
-            //Axis check for Belted shaft (they don't count as "shaft" shaft)
-            boolean compatibleAxis = ke.getRotationAxis(innerState) == wheelAxis;
-            hasKineticConnection = hasShaft || compatibleAxis;
-        }
-
-        if (hasKineticConnection) {
+        if (innerState.getBlock() instanceof KineticBlock ke && ke.hasShaftTowards(level, this.getBlockPos(), innerState, dir.getOpposite())) {
             isFreespin = false;
         } else {
             isFreespin = true;


### PR DESCRIPTION
Belted shafts aren't passing hasShaftTowards() --> Means power aren't going to the wheels when it's powered by one, even though it still passes through. Added axis check for create-based components like belted shafts. minimal changes so it should work.