### PR TITLE
fixed dampening decouple from twp port

### DIFF
--- a/src/main/java/edn/stratodonut/trackwork/tracks/forces/OleoWheelController.java
+++ b/src/main/java/edn/stratodonut/trackwork/tracks/forces/OleoWheelController.java
@@ -55,7 +55,6 @@ public final class OleoWheelController implements ShipPhysicsListener {
 
     private volatile Vector3dc suspensionAdjust = new Vector3d(0, 1, 0);
     private volatile float suspensionStiffness = 1.0f;
-    private volatile float suspensionDampening = 1.2f;
 
     public OleoWheelController() {}
 
@@ -156,7 +155,7 @@ public final class OleoWheelController implements ShipPhysicsListener {
             tForce.add(springForce);
 
             // Less damper downward
-            double damperMagnitude = m * -suspensionDelta * coefficientOfPower * this.suspensionDampening;
+            double damperMagnitude = m * 1.2 * -suspensionDelta * coefficientOfPower * this.suspensionStiffness;
             if (damperMagnitude > 0) {
                 damperMagnitude *= 0.5;
             }

--- a/src/main/java/edn/stratodonut/trackwork/tracks/forces/PhysicsTrackController.java
+++ b/src/main/java/edn/stratodonut/trackwork/tracks/forces/PhysicsTrackController.java
@@ -60,9 +60,6 @@ public final class PhysicsTrackController implements ShipPhysicsListener {
 
     private volatile Vector3dc suspensionAdjust = new Vector3d(0, 1, 0);
     private volatile float suspensionStiffness = 1.0f;
-    @JsonIgnore
-    @Deprecated(forRemoval = true)
-    private volatile float suspensionDampening = 1.2f;
 
     public PhysicsTrackController () {}
 

--- a/src/main/java/edn/stratodonut/trackwork/tracks/forces/SimpleWheelController.java
+++ b/src/main/java/edn/stratodonut/trackwork/tracks/forces/SimpleWheelController.java
@@ -64,7 +64,6 @@ public final class SimpleWheelController implements ShipPhysicsListener {
 
     private volatile Vector3dc suspensionAdjust = new Vector3d(0, 1, 0);
     private volatile float suspensionStiffness = 1.0f;
-    private volatile float suspensionDampening = 1.2f;
 
     public SimpleWheelController() {}
 
@@ -186,7 +185,7 @@ public final class SimpleWheelController implements ShipPhysicsListener {
             tForce.add(springForce);
 
             // Damper force (dampening) - apply in world coordinates but calculated relative to local up
-            Vector3dc damperForce = trackNormal.mul(m * -suspensionDelta * coefficientOfPower * this.suspensionDampening, new Vector3d());
+            Vector3dc damperForce = trackNormal.mul(m * 1.2 * -suspensionDelta * coefficientOfPower * this.suspensionStiffness, new Vector3d());
             tForce.add(damperForce);
             // Really half-assed antislip when the spring is stronger than friction (what?)
             if (data.wheelRPM == 0) {


### PR DESCRIPTION
Re-wired dampening to use `suspensionStiffness` instead of `suspensionDampening` across simplewheel and oleowheel

also removed deprecated dampening from tracks but that isnt affected by the decoupling.

fixes #65 